### PR TITLE
from __future__ import print_function works on Py2

### DIFF
--- a/smartinfo.py
+++ b/smartinfo.py
@@ -12,6 +12,7 @@
 #   Auto-generated stopwords file in folder output (filename: auto_stopwords.csv)
 #
 
+from __future__ import print_function
 import sys
 import getopt
 import sqlite3 as sql


### PR DESCRIPTION
Before this PR,  the print() call on line 364 would fail on Python 2 because the `end` and `flush` parameters not part of the Python 2 print statement.  The `from __future__ import print_function` statement make print() work identically in both Python 2 and Python 3.

`print("\rSaved: %d" % cnt, end='', flush=True)`